### PR TITLE
Add Travis CI to this repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -212,3 +212,12 @@ Run the web service:
 5. If the [authentication](docs/Authentication.md) has been set up successfully, then [http://localhost:8080/openhmis/api/v3/healthcheck/authentication](http://localhost:8080/openhmis/api/v3/healthcheck/authentication) should display "You have a valid authentication token."
 
 6.  Once authentication works, if the schema is properly set up, [http://localhost:8080/openhmis/api/v3/clients](http://localhost:8080/openhmis/api/v3/clients) should yield a valid XML object.
+
+Continuous integration:
+----------------------
+
+To set up continuous integration for a fork of this repository, follow
+the instructions at
+[Travis](https://docs.travis-ci.com/user/getting-started/).  We've
+already added the .travis.yml file to this repo, so all you need to do
+is turn on CI for your fork, as described on that page.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 OpenHMIS
 ========
 
+Current build status:  ![Build status](https://travis-ci.org/cecilia-donnelly/OpenHMIS.svg?branch=master)
+
 The OpenHMIS project is an [open source](LICENSE.md),
 [standards-based](docs/API.md) HMIS (Homeless Management Information
 System).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OpenHMIS
 ========
 
-Current build status:  ![Build status](https://travis-ci.org/cecilia-donnelly/OpenHMIS.svg?branch=master)
+Current build status:  ![Build status](https://travis-ci.org/hmis-tools/hmis-api-server.svg?branch=master)
 
 The OpenHMIS project is an [open source](LICENSE.md),
 [standards-based](docs/API.md) HMIS (Homeless Management Information


### PR DESCRIPTION
Add a yml file to tell Travis what kind of tests to run (just `mvn test`, for now) show the build status in the README, and add a few instructions about CI to the INSTALL file.

Note that once this change has been merged and Travis has been turned on for the hmis-tools/hmis-api-server repo we'll need to change the image link in README.md to the url corresponding to that repo.
