### PR TITLE
Pass information about a user via an endpoint: #68

### DIFF
--- a/src/main/java/org/openhmis/dao/TmpTokenCacheDAO.java
+++ b/src/main/java/org/openhmis/dao/TmpTokenCacheDAO.java
@@ -54,7 +54,7 @@ public class TmpTokenCacheDAO extends BaseDAO {
 	public TmpTokenCache getTmpTokenCacheByIdToken(String idToken)  {
 		String queryString = "select tokenCache " + 
 			"from TmpTokenCache as tokenCache " + 
-			"where tokenCache.id_token =:idToken";
+			"where tokenCache.idToken =:idToken";
 		
 		Session session = getSession();
 		Query queryObject = session.createQuery(queryString);

--- a/src/main/java/org/openhmis/dao/TmpTokenCacheDAO.java
+++ b/src/main/java/org/openhmis/dao/TmpTokenCacheDAO.java
@@ -1,0 +1,84 @@
+package org.openhmis.dao;
+
+
+import java.util.Date;
+import java.util.List;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.openhmis.domain.TmpTokenCache;
+
+public class TmpTokenCacheDAO extends BaseDAO {
+
+	public TmpTokenCacheDAO() {
+	}
+    
+	public TmpTokenCache getTmpTokenCacheById(Integer tokenCacheId)  {
+		String queryString = "select tokenCache " + 
+			"from TmpTokenCache as tokenCache " + 
+			"where tokenCache.tokenCacheId =:tokenCacheId";
+
+		Session session = getSession();
+		Query queryObject = session.createQuery(queryString);
+		queryObject.setParameter("tokenCacheId", tokenCacheId);
+		queryObject.setMaxResults(1);
+		
+		List<TmpTokenCache> results = queryObject.list();
+		session.close();
+		
+		if(results.size() > 0)
+			return (TmpTokenCache)results.get(0);
+		else
+			return null;
+	}
+
+	public TmpTokenCache getTmpTokenCacheByUserId(String userId)  {
+		String queryString = "select tokenCache " + 
+			"from TmpTokenCache as tokenCache " + 
+			"where tokenCache.userId =:userId";
+		
+		Session session = getSession();
+		Query queryObject = session.createQuery(queryString);
+		queryObject.setParameter("userId", userId);
+		queryObject.setMaxResults(1);
+		
+		List<TmpTokenCache> results = queryObject.list();
+		session.close();
+		
+		if(results.size() > 0)
+			return (TmpTokenCache)results.get(0);
+		else
+			return null;
+	}
+
+	public TmpTokenCache getTmpTokenCacheByIdToken(String idToken)  {
+		String queryString = "select tokenCache " + 
+			"from TmpTokenCache as tokenCache " + 
+			"where tokenCache.id_token =:idToken";
+		
+		Session session = getSession();
+		Query queryObject = session.createQuery(queryString);
+		queryObject.setParameter("idToken", idToken);
+		queryObject.setMaxResults(1);
+		
+		List<TmpTokenCache> results = queryObject.list();
+		session.close();
+		
+		if(results.size() > 0)
+			return (TmpTokenCache)results.get(0);
+		else
+			return null;
+	}
+    
+	@SuppressWarnings("unchecked")
+	public List<TmpTokenCache> getTmpTokenCaches() {
+		String queryString = "select tokenCache " + 
+				"from TmpTokenCache as tokenCache";
+
+		Session session = getSession();
+		Query queryObject = session.createQuery(queryString);
+		List<TmpTokenCache> results = queryObject.list();
+		session.close();
+		return results;
+	}
+}

--- a/src/main/java/org/openhmis/dao/TmpTokenCacheDAO.java
+++ b/src/main/java/org/openhmis/dao/TmpTokenCacheDAO.java
@@ -32,14 +32,14 @@ public class TmpTokenCacheDAO extends BaseDAO {
 			return null;
 	}
 
-	public TmpTokenCache getTmpTokenCacheByUserId(String userId)  {
+	public TmpTokenCache getTmpTokenCacheByExternalId(String externalId)  {
 		String queryString = "select tokenCache " + 
 			"from TmpTokenCache as tokenCache " + 
-			"where tokenCache.userId =:userId";
+			"where tokenCache.externalId =:externalId";
 		
 		Session session = getSession();
 		Query queryObject = session.createQuery(queryString);
-		queryObject.setParameter("userId", userId);
+		queryObject.setParameter("externalId", externalId);
 		queryObject.setMaxResults(1);
 		
 		List<TmpTokenCache> results = queryObject.list();

--- a/src/main/java/org/openhmis/domain/TmpTokenCache.java
+++ b/src/main/java/org/openhmis/domain/TmpTokenCache.java
@@ -18,7 +18,7 @@ import javax.persistence.TemporalType;
 @Table(name = "TMP_TOKEN_CACHE")
 public class TmpTokenCache implements java.io.Serializable {
         private Integer tokenCacheId;
-	private Integer userId;
+	private String externalId;
         private String idToken;
 	private Date dateCreated;
 	private Date dateUpdated;
@@ -26,11 +26,11 @@ public class TmpTokenCache implements java.io.Serializable {
 	public TmpTokenCache() {
 	}
 
-        public TmpTokenCache(Integer tokenCacheId, Integer userId,
+        public TmpTokenCache(Integer tokenCacheId, String externalId,
                          String idToken,
 			Date dateCreated, Date dateUpdated) {
                 this.tokenCacheId = tokenCacheId;
-		this.userId = userId;
+		this.externalId = externalId;
                 this.idToken = idToken;
 		this.dateCreated = dateCreated;
 		this.dateUpdated = dateUpdated;
@@ -47,13 +47,13 @@ public class TmpTokenCache implements java.io.Serializable {
 		this.tokenCacheId = tokenCacheId;
 	}
 
-        @Column(name = "userId")
-	public Integer getUserId() {
-		return this.userId;
+        @Column(name = "externalId")
+	public String getExternalId() {
+		return this.externalId;
 	}
 
-	public void setUserId(Integer userId) {
-		this.userId = userId;
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
 	}
 
         @Column(name = "idToken")

--- a/src/main/java/org/openhmis/domain/TmpTokenCache.java
+++ b/src/main/java/org/openhmis/domain/TmpTokenCache.java
@@ -1,0 +1,88 @@
+package org.openhmis.domain;
+
+
+
+// Generated July 27, 2016 1:21:15 PM by cdonnelly
+
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import static javax.persistence.GenerationType.IDENTITY;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+@Entity
+@Table(name = "TMP_TOKEN_CACHE")
+public class TmpTokenCache implements java.io.Serializable {
+        private Integer tokenCacheId;
+	private Integer userId;
+        private String idToken;
+	private Date dateCreated;
+	private Date dateUpdated;
+
+	public TmpTokenCache() {
+	}
+
+        public TmpTokenCache(Integer tokenCacheId, Integer userId,
+                         String idToken,
+			Date dateCreated, Date dateUpdated) {
+                this.tokenCacheId = tokenCacheId;
+		this.userId = userId;
+                this.idToken = idToken;
+		this.dateCreated = dateCreated;
+		this.dateUpdated = dateUpdated;
+	}
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "tokenCacheId", unique = true, nullable = false)
+	public Integer getTokenCacheId() {
+		return this.tokenCacheId;
+	}
+
+	public void setTokenCacheId(Integer tokenCacheId) {
+		this.tokenCacheId = tokenCacheId;
+	}
+
+        @Column(name = "userId")
+	public Integer getUserId() {
+		return this.userId;
+	}
+
+	public void setUserId(Integer userId) {
+		this.userId = userId;
+	}
+
+        @Column(name = "idToken")
+	public String getIdToken() {
+		return this.idToken;
+	}
+
+	public void setIdToken(String idToken) {
+		this.idToken = idToken;
+	}
+
+        @Temporal(TemporalType.DATE)
+	@Column(name = "dateCreated", length = 10)
+	public Date getDateCreated() {
+		return this.dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	@Temporal(TemporalType.DATE)
+	@Column(name = "dateUpdated", length = 10)
+	public Date getDateUpdated() {
+		return this.dateUpdated;
+	}
+
+	public void setDateUpdated(Date dateUpdated) {
+		this.dateUpdated = dateUpdated;
+	}
+
+}

--- a/src/main/java/org/openhmis/dto/AccountDTO.java
+++ b/src/main/java/org/openhmis/dto/AccountDTO.java
@@ -1,0 +1,49 @@
+
+
+package org.openhmis.dto;
+
+
+import java.util.Date;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.openhmis.code.None;
+import org.openhmis.code.YesNo;
+import org.openhmis.code.YesNoReason;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import org.openhmis.dto.UserDTO;
+
+
+@XmlRootElement
+public class AccountDTO extends BaseDTO {
+    private String externalId;
+    private UserDTO user;
+
+    public AccountDTO() {}
+
+    @JsonProperty
+    public String getExternalId() {
+        return this.externalId;
+    }
+
+    @JsonProperty
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    @JsonProperty
+    public UserDTO getUser() {
+        return this.user;
+    }
+
+    @JsonProperty
+    public void setUser(UserDTO user) {
+        this.user = user;
+    }
+    
+}

--- a/src/main/java/org/openhmis/dto/TokenCacheDTO.java
+++ b/src/main/java/org/openhmis/dto/TokenCacheDTO.java
@@ -1,0 +1,85 @@
+package org.openhmis.dto;
+
+
+import java.util.Date;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.openhmis.code.YesNoReason;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@XmlRootElement
+public class TokenCacheDTO extends BaseDTO {
+
+        private Integer tokenCacheId;
+    	private Integer userId;
+        private String idToken;
+    
+	// Export Standard Fields
+	private Date dateCreated;
+	private Date dateUpdated;
+
+    public TokenCacheDTO() {}
+
+    	@JsonProperty
+	public Integer getId() {
+		return tokenCacheId;
+	}
+
+	@JsonProperty
+	public void setId(Integer tokenCacheId) {
+		this.tokenCacheId = tokenCacheId;
+	}
+
+        @JsonProperty
+	public Integer getTokenCacheId() {
+		return tokenCacheId;
+	}
+
+	@JsonProperty
+	public void setTokenCacheId(Integer tokenCacheId) {
+		this.tokenCacheId = tokenCacheId;
+	}
+
+	@JsonProperty
+	public Integer getUserId() {
+		return userId;
+	}
+
+	@JsonProperty
+	public void setUserId(Integer userId) {
+		this.userId = userId;
+	}
+
+	@JsonProperty
+	public String getIdToken() {
+		return idToken;
+	}
+
+	@JsonProperty
+	public void setIdToken(String idToken) {
+		this.idToken = idToken;
+	}
+
+        @JsonProperty
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	@JsonProperty
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	@JsonProperty
+	public Date getDateUpdated() {
+		return dateUpdated;
+	}
+
+	@JsonProperty
+	public void setDateUpdated(Date dateUpdated) {
+		this.dateUpdated = dateUpdated;
+	}
+    
+}

--- a/src/main/java/org/openhmis/dto/TokenCacheDTO.java
+++ b/src/main/java/org/openhmis/dto/TokenCacheDTO.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class TokenCacheDTO extends BaseDTO {
 
         private Integer tokenCacheId;
-    	private Integer userId;
+    	private String externalId;
         private String idToken;
     
 	// Export Standard Fields
@@ -43,13 +43,13 @@ public class TokenCacheDTO extends BaseDTO {
 	}
 
 	@JsonProperty
-	public Integer getUserId() {
-		return userId;
+	public String getExternalId() {
+		return externalId;
 	}
 
 	@JsonProperty
-	public void setUserId(Integer userId) {
-		this.userId = userId;
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
 	}
 
 	@JsonProperty

--- a/src/main/java/org/openhmis/manager/TokenCacheManager.java
+++ b/src/main/java/org/openhmis/manager/TokenCacheManager.java
@@ -86,8 +86,8 @@ public class TokenCacheManager {
 		TokenCacheDTO tokenCacheDTO = new TokenCacheDTO();
 
 		tokenCacheDTO.setTokenCacheId(tmpTokenCache.getTokenCacheId());
-                tmpTokenCache.setUserId(tmpTokenCache.getUserId());
-                tmpTokenCache.setIdToken(tmpTokenCache.getIdToken());
+                tokenCacheDTO.setUserId(tmpTokenCache.getUserId());
+                tokenCacheDTO.setIdToken(tmpTokenCache.getIdToken());
 		
 		// Export Standard Fields (TBD: what are "Standard Fields"?)
 		tokenCacheDTO.setDateCreated(tmpTokenCache.getDateCreated());

--- a/src/main/java/org/openhmis/manager/TokenCacheManager.java
+++ b/src/main/java/org/openhmis/manager/TokenCacheManager.java
@@ -1,0 +1,112 @@
+package org.openhmis.manager;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import org.openhmis.dao.TmpTokenCacheDAO;
+import org.openhmis.domain.TmpTokenCache;
+import org.openhmis.dto.TokenCacheDTO;
+
+public class TokenCacheManager {
+	private static final TmpTokenCacheDAO tmpTokenCacheDAO = new TmpTokenCacheDAO();
+
+	public TokenCacheManager() {}
+
+	public static TokenCacheDTO getTokenCacheById(String tokenCacheId) {
+		TokenCacheDTO tokenCacheDTO = TokenCacheManager.generateTokenCacheDTO(tmpTokenCacheDAO.getTmpTokenCacheById(Integer.parseInt(tokenCacheId)));
+		return tokenCacheDTO;
+	}
+
+	public static List<TokenCacheDTO> getTokenCaches() {
+		List<TokenCacheDTO> tokenCacheDTOs = new ArrayList<TokenCacheDTO>();
+
+		// Collect the tokenCaches
+		List<TmpTokenCache> tmpTokenCaches = tmpTokenCacheDAO.getTmpTokenCaches();
+
+		// For each TmpTokenCache, collect and map the data
+		for (Iterator<TmpTokenCache> iterator = tmpTokenCaches.iterator(); iterator.hasNext();) {
+			TmpTokenCache tmpTokenCache = iterator.next();
+			TokenCacheDTO tokenCacheDTO = TokenCacheManager.generateTokenCacheDTO(tmpTokenCache);
+			tokenCacheDTOs.add(tokenCacheDTO);
+		}
+		return tokenCacheDTOs;
+	}
+
+	public static TokenCacheDTO getTokenCacheByIdToken(String idToken) {
+		
+		// Collect the tokenCaches
+		TmpTokenCache tmpTokenCache = tmpTokenCacheDAO.getTmpTokenCacheByIdToken(idToken);
+
+		TokenCacheDTO tokenCacheDTO = TokenCacheManager.generateTokenCacheDTO(tmpTokenCache);
+		return tokenCacheDTO;
+
+	}
+	
+	public static TokenCacheDTO addTokenCache(TokenCacheDTO inputDTO) {
+		// Generate a TmpTokenCache from the input
+		TmpTokenCache tmpTokenCache = TokenCacheManager.generateTmpTokenCache(inputDTO);
+		
+		// Set Export fields (TBD: is Export right here?)
+		tmpTokenCache.setDateCreated(new Date());
+		tmpTokenCache.setDateUpdated(new Date());
+		
+		// Save the tokenCache to allow secondary object generation
+		tmpTokenCacheDAO.save(tmpTokenCache);
+		inputDTO.setTokenCacheId(tmpTokenCache.getTokenCacheId());
+		
+		// Return the resulting DTO
+		return TokenCacheManager.generateTokenCacheDTO(tmpTokenCache);
+	}
+	
+	public static TokenCacheDTO updateTokenCache(TokenCacheDTO inputDTO) {
+		// Generate a tokenCache from the input
+		TmpTokenCache tmpTokenCache = TokenCacheManager.generateTmpTokenCache(inputDTO);
+		tmpTokenCache.setTokenCacheId(inputDTO.getTokenCacheId());
+		tmpTokenCache.setDateUpdated(new Date());
+                tmpTokenCache.setUserId(inputDTO.getUserId());
+                tmpTokenCache.setIdToken(inputDTO.getIdToken());
+		
+		// Update the object
+		tmpTokenCacheDAO.update(tmpTokenCache);
+		
+		// Return the resulting DTO
+		return TokenCacheManager.generateTokenCacheDTO(tmpTokenCache);
+
+	}
+	
+	public static boolean deleteTokenCache(String tokenCacheId) {
+		TmpTokenCache tmpTokenCache = tmpTokenCacheDAO.getTmpTokenCacheById(Integer.parseInt(tokenCacheId));
+		tmpTokenCacheDAO.delete(tmpTokenCache);
+		return true;
+	}
+	
+	public static TokenCacheDTO generateTokenCacheDTO(TmpTokenCache tmpTokenCache) {
+		TokenCacheDTO tokenCacheDTO = new TokenCacheDTO();
+
+		tokenCacheDTO.setTokenCacheId(tmpTokenCache.getTokenCacheId());
+                tmpTokenCache.setUserId(tmpTokenCache.getUserId());
+                tmpTokenCache.setIdToken(tmpTokenCache.getIdToken());
+		
+		// Export Standard Fields (TBD: what are "Standard Fields"?)
+		tokenCacheDTO.setDateCreated(tmpTokenCache.getDateCreated());
+		tokenCacheDTO.setDateUpdated(tmpTokenCache.getDateUpdated());
+		
+		return tokenCacheDTO;
+	}
+	
+	public static TmpTokenCache generateTmpTokenCache(TokenCacheDTO inputDTO) {
+		TmpTokenCache tmpTokenCache = new TmpTokenCache();
+		
+		tmpTokenCache.setUserId(inputDTO.getUserId());
+		tmpTokenCache.setIdToken(inputDTO.getIdToken());
+		
+		// Export Standard Fields (TBD: what are "Standard Fields"?)
+		tmpTokenCache.setDateCreated(inputDTO.getDateCreated());
+		tmpTokenCache.setDateUpdated(inputDTO.getDateUpdated());
+		
+		return tmpTokenCache;
+	}
+	
+}

--- a/src/main/java/org/openhmis/manager/TokenCacheManager.java
+++ b/src/main/java/org/openhmis/manager/TokenCacheManager.java
@@ -65,7 +65,7 @@ public class TokenCacheManager {
 		TmpTokenCache tmpTokenCache = TokenCacheManager.generateTmpTokenCache(inputDTO);
 		tmpTokenCache.setTokenCacheId(inputDTO.getTokenCacheId());
 		tmpTokenCache.setDateUpdated(new Date());
-                tmpTokenCache.setUserId(inputDTO.getUserId());
+                tmpTokenCache.setExternalId(inputDTO.getExternalId());
                 tmpTokenCache.setIdToken(inputDTO.getIdToken());
 		
 		// Update the object
@@ -86,7 +86,7 @@ public class TokenCacheManager {
 		TokenCacheDTO tokenCacheDTO = new TokenCacheDTO();
 
 		tokenCacheDTO.setTokenCacheId(tmpTokenCache.getTokenCacheId());
-                tokenCacheDTO.setUserId(tmpTokenCache.getUserId());
+                tokenCacheDTO.setExternalId(tmpTokenCache.getExternalId());
                 tokenCacheDTO.setIdToken(tmpTokenCache.getIdToken());
 		
 		// Export Standard Fields (TBD: what are "Standard Fields"?)
@@ -99,7 +99,7 @@ public class TokenCacheManager {
 	public static TmpTokenCache generateTmpTokenCache(TokenCacheDTO inputDTO) {
 		TmpTokenCache tmpTokenCache = new TmpTokenCache();
 		
-		tmpTokenCache.setUserId(inputDTO.getUserId());
+		tmpTokenCache.setExternalId(inputDTO.getExternalId());
 		tmpTokenCache.setIdToken(inputDTO.getIdToken());
 		
 		// Export Standard Fields (TBD: what are "Standard Fields"?)

--- a/src/main/java/org/openhmis/util/Authentication.java
+++ b/src/main/java/org/openhmis/util/Authentication.java
@@ -113,6 +113,9 @@ public class Authentication {
                 if (user != null) {
                          tmpUser = tmpUserDAO.getTmpUserById(Integer.parseInt(user.getUserId()));
                 }
+                else {
+                    tmpUser = null;
+                }
 			
 			
                 switch(authType) {

--- a/src/main/java/org/openhmis/util/Authentication.java
+++ b/src/main/java/org/openhmis/util/Authentication.java
@@ -29,6 +29,7 @@ import org.openhmis.domain.TmpUser;
 import org.openhmis.exception.AuthenticationFailureException;
 import org.openhmis.manager.TokenCacheManager;
 import org.openhmis.manager.UserManager;
+import org.openhmis.dto.AccountDTO;
 import org.openhmis.dto.TokenCacheDTO;
 import org.openhmis.dto.UserDTO;
 
@@ -89,22 +90,30 @@ public class Authentication {
                 if(tokenString == null)
                         return false;
                 
-                Integer userId = resolveIdentity(tokenString);
+                AccountDTO account = resolveIdentity(tokenString);
 			
-                log.debug("Login attempt:" + userId);
+                log.debug("Login attempt:" + account.getExternalId());
 			
+                // If the user doesn't exist for Google, then the account
+                // should be null and they aren't authorized
+                if(account.getExternalId() == null)
+                        return false;
+
+                
                 // Make sure this user has the requested credentials
                 TmpUserDAO tmpUserDAO = new TmpUserDAO();
                 /*
                  * TBD: does this throw exceptions?  If so, where are
                  * they caught?
                  */
-                TmpUser tmpUser = tmpUserDAO.getTmpUserById(userId);
+                // get the user from the account
+                UserDTO user = account.getUser();
+                TmpUser tmpUser = new TmpUser();
+                
+                if (user != null) {
+                         tmpUser = tmpUserDAO.getTmpUserById(Integer.parseInt(user.getUserId()));
+                }
 			
-                // If the user doesn't exist for Google, then the userId
-                // should be -1 and they aren't authorized
-                if(userId < 0)
-                        return false;
 			
                 switch(authType) {
                 case Authentication.EXISTS:
@@ -128,40 +137,39 @@ public class Authentication {
         }
 
         /*
-         * Given the id token, return the id of the user that it
-         * represents.  If the user exists in the database the id will
-         * be greater than 0.  If the id token is valid but the user
-         * does *not* exist in the database, the id will be equal to 0.
-         * If the id token is not valid then the id will be -1 (less
-         * than 0), and they should not be allowed even READ access.  
+         * Given the id token, return the external ID (usually an email
+         * address) and, if the user exists in the database, the user
+         * object.  If the user doesn't exist, the user object will be
+         * null/empty.
          *
-         * This seems pretty hacky to me, so I would welcome help with
-         * doing it better!  I'm just not sure how to preserve the "give
-         * all signed-in Google users READ access" with the current
-         * cache table structure.  One way to do it would be to add a
-         * column for "externalId" to the cache table, but then we're
-         * storing the externalId two different places.  I'd prefer to
-         * just use the userId and join the tables on that, BUT it
-         * doesn't work for people who've authenticated to Google (i.e.,
-         * have an externalId) but aren't in our users list (so don't
-         * have a userId).
-         * 
+         * With this endpoint, the client will display either just the
+         * external ID or, if available, more information about the
+         * user.
+         *
+         * If the id token is bad in some way, currently we return an
+         * empty object, but see the TODO note below -- we should pass
+         * an error.
+         *
         */
-        public static Integer resolveIdentity(String id_token) {
+        public static AccountDTO resolveIdentity(String id_token) {
             // look this up in TMP_TOKEN_CACHE first. Test whether the
-            // dateCreated/dateUpdated value are less than a day old
-            // (i.e. not expired).  If it does not exist or is too old,
-            // then go into the Google retrieval routine.
+            // dateCreated or dateUpdated value is less than a day old
+            // (i.e. not expired).  If the token does not exist or is
+            // too old, then go into the Google retrieval routine.
             //
-            Integer userId = -1;
+            String externalId = "";
+            AccountDTO accountDTO = new AccountDTO();
+            
             try {
                 TokenCacheDTO tokenCacheDTO = TokenCacheManager.getTokenCacheByIdToken(id_token);
                 // TODO: At some point, we'll add a timeout here
-                userId = tokenCacheDTO.getUserId();
+                externalId = tokenCacheDTO.getExternalId();
+                UserDTO userDTO = UserManager.getUserByExternalId(externalId);
+                accountDTO.setUser(userDTO);
+                accountDTO.setExternalId(externalId);
             }
             catch (Exception noRecord) {
-                // no valid token was found
-                log.info ("Exception: no valid token found: " + noRecord.toString());
+                log.info ("Exception: no cache record found: " + noRecord.toString());
                 try {
                     // Verify that the token is a legitimate google token
                     GoogleIdToken token = GoogleIdToken.parse(JSON_FACTORY, id_token);
@@ -169,46 +177,52 @@ public class Authentication {
                     verifier.verify(token);
     			
                     // If we get here then this is a valid google item
-                    String externalId = token.getPayload().getEmail();
+                    externalId = token.getPayload().getEmail();
+                    accountDTO.setExternalId(externalId);
 
                     try {
-                        // TBD: This will fail if the user doesn't
-                        // exist, which is a problem because we want to
-                        // allow all auth'd users to READ, even if they
-                        // don't exist in the db.
-                        //
                         // get user id from external id
                         UserDTO userDTO = UserManager.getUserByExternalId(externalId);
-                        userId = Integer.parseInt(userDTO.getUserId());
+                        accountDTO.setUser(userDTO);
 
-                        // Create a new entry in the TMP_TOKEN_CACHE table.
-                        // TODO: Delete old entries for this user id.
-                        TokenCacheDTO inputDTO = new TokenCacheDTO();
-                        inputDTO.setIdToken(id_token);
-                        inputDTO.setUserId(userId);
-                        TokenCacheManager.addTokenCache(inputDTO);
                     }
                     catch (Exception noUser){
                         log.info("User " + externalId + " does not exist in the database.");
-                        userId = 0;
+                        accountDTO.setUser(null);
                     }
                     
+                    // Create a new entry in the TMP_TOKEN_CACHE table.
+                    // TODO: Delete old entries for this user id.
+                    TokenCacheDTO inputDTO = new TokenCacheDTO();
+                    inputDTO.setIdToken(id_token);
+                    inputDTO.setExternalId(externalId);
+                    TokenCacheManager.addTokenCache(inputDTO);
+
+                    /*
+                     * TODO: Instead of just sending an empty object
+                     * back in these various "catch" scenarios, we
+                     * probably want to send the client an error, since
+                     * these imply that the token is bad.
+                     */
 		} catch (IOException e) {
 			log.debug("IOException authenticating with Google: " + e.toString());
-                        userId = -1;
+                        accountDTO.setUser(null);
+                        accountDTO.setExternalId(null);
 		} catch (GeneralSecurityException e) {
 			log.debug("GeneralSecurityException authenticating with Google: " + e.toString());
-                        userId = -1;
+                        accountDTO.setUser(null);
+                        accountDTO.setExternalId(null);
 		} catch (IllegalArgumentException e) {
 			log.debug("IllegalArgumentException authenticating with Google: " + e.toString());
-                        userId = -1;
+                        accountDTO.setUser(null);
+                        accountDTO.setExternalId(null);
 		} catch (Exception e) {
 			log.debug("Unexpected exception authenticating with Google: " + e.toString());
-                        userId = -1;
+                        accountDTO.setUser(null);
+                        accountDTO.setExternalId(null);
 		}
             }
-            
-            return userId;
+            return accountDTO;
         }
 
 }

--- a/src/main/java/org/openhmis/util/Authentication.java
+++ b/src/main/java/org/openhmis/util/Authentication.java
@@ -89,9 +89,9 @@ public class Authentication {
                 if(tokenString == null)
                         return false;
                 
-                String externalId = resolveIdentity(tokenString);
+                Integer userId = resolveIdentity(tokenString);
 			
-                log.debug("Login attempt:" + externalId);
+                log.debug("Login attempt:" + userId);
 			
                 // Make sure this user has the requested credentials
                 TmpUserDAO tmpUserDAO = new TmpUserDAO();
@@ -99,10 +99,11 @@ public class Authentication {
                  * TBD: does this throw exceptions?  If so, where are
                  * they caught?
                  */
-                TmpUser tmpUser = tmpUserDAO.getTmpUserByExternalId(externalId);
+                TmpUser tmpUser = tmpUserDAO.getTmpUserById(userId);
 			
-                // If the user doesn't exist, they aren't authorized
-                if(externalId == null)
+                // If the user doesn't exist for Google, then the userId
+                // should be -1 and they aren't authorized
+                if(userId < 0)
                         return false;
 			
                 switch(authType) {
@@ -127,23 +128,40 @@ public class Authentication {
         }
 
         /*
-         * Given the id token, return the identity represented (usually a
-         * Google email address, for now).
+         * Given the id token, return the id of the user that it
+         * represents.  If the user exists in the database the id will
+         * be greater than 0.  If the id token is valid but the user
+         * does *not* exist in the database, the id will be equal to 0.
+         * If the id token is not valid then the id will be -1 (less
+         * than 0), and they should not be allowed even READ access.  
+         *
+         * This seems pretty hacky to me, so I would welcome help with
+         * doing it better!  I'm just not sure how to preserve the "give
+         * all signed-in Google users READ access" with the current
+         * cache table structure.  One way to do it would be to add a
+         * column for "externalId" to the cache table, but then we're
+         * storing the externalId two different places.  I'd prefer to
+         * just use the userId and join the tables on that, BUT it
+         * doesn't work for people who've authenticated to Google (i.e.,
+         * have an externalId) but aren't in our users list (so don't
+         * have a userId).
+         * 
         */
-        public static String resolveIdentity(String id_token) {
+        public static Integer resolveIdentity(String id_token) {
             // look this up in TMP_TOKEN_CACHE first. Test whether the
             // dateCreated/dateUpdated value are less than a day old
             // (i.e. not expired).  If it does not exist or is too old,
             // then go into the Google retrieval routine.
             //
-            String externalId;
+            Integer userId = -1;
             try {
                 TokenCacheDTO tokenCacheDTO = TokenCacheManager.getTokenCacheByIdToken(id_token);
-                externalId = tokenCacheDTO.getUserId().toString();
+                // TODO: At some point, we'll add a timeout here
+                userId = tokenCacheDTO.getUserId();
             }
             catch (Exception noRecord) {
-                // no token was found
-                log.info ("Exception: no cached token found " + noRecord.toString());
+                // no valid token was found
+                log.info ("Exception: no valid token found: " + noRecord.toString());
                 try {
                     // Verify that the token is a legitimate google token
                     GoogleIdToken token = GoogleIdToken.parse(JSON_FACTORY, id_token);
@@ -151,34 +169,46 @@ public class Authentication {
                     verifier.verify(token);
     			
                     // If we get here then this is a valid google item
-                    externalId = token.getPayload().getEmail();
+                    String externalId = token.getPayload().getEmail();
 
-                    // get user id from external id
-                    UserDTO userDTO = UserManager.getUserByExternalId(externalId);
-                    String userID = userDTO.getUserId();
-                    // TBD: what happens if the user doesn't exist?
+                    try {
+                        // TBD: This will fail if the user doesn't
+                        // exist, which is a problem because we want to
+                        // allow all auth'd users to READ, even if they
+                        // don't exist in the db.
+                        //
+                        // get user id from external id
+                        UserDTO userDTO = UserManager.getUserByExternalId(externalId);
+                        userId = Integer.parseInt(userDTO.getUserId());
 
-                    // create a new entry in the TMP_TOKEN_CACHE table
-                    TokenCacheDTO inputDTO = new TokenCacheDTO();
-                    inputDTO.setIdToken(id_token);
-                    inputDTO.setUserId(Integer.parseInt(userID));
-                    TokenCacheManager.addTokenCache(inputDTO);
+                        // Create a new entry in the TMP_TOKEN_CACHE table.
+                        // TODO: Delete old entries for this user id.
+                        TokenCacheDTO inputDTO = new TokenCacheDTO();
+                        inputDTO.setIdToken(id_token);
+                        inputDTO.setUserId(userId);
+                        TokenCacheManager.addTokenCache(inputDTO);
+                    }
+                    catch (Exception noUser){
+                        log.info("User " + externalId + " does not exist in the database.");
+                        userId = 0;
+                    }
                     
 		} catch (IOException e) {
 			log.debug("IOException authenticating with Google: " + e.toString());
-                        externalId = null;
+                        userId = -1;
 		} catch (GeneralSecurityException e) {
 			log.debug("GeneralSecurityException authenticating with Google: " + e.toString());
-                        externalId = null;
+                        userId = -1;
 		} catch (IllegalArgumentException e) {
 			log.debug("IllegalArgumentException authenticating with Google: " + e.toString());
-                        externalId = null;
+                        userId = -1;
 		} catch (Exception e) {
 			log.debug("Unexpected exception authenticating with Google: " + e.toString());
-                        externalId = null;
+                        userId = -1;
 		}
             }
-                return externalId;
+            
+            return userId;
         }
 
 }

--- a/src/main/java/org/openhmis/util/Authentication.java
+++ b/src/main/java/org/openhmis/util/Authentication.java
@@ -148,10 +148,9 @@ public class Authentication {
          *
         */
         public static AccountDTO resolveIdentity(String id_token) {
-            // look this up in TMP_TOKEN_CACHE first. Test whether the
-            // dateCreated or dateUpdated value is less than a day old
-            // (i.e. not expired).  If the token does not exist or is
-            // too old, then go into the Google retrieval routine.
+            // Look this up in TMP_TOKEN_CACHE first. If the token does
+            // not exist or is too old, then go into the Google
+            // retrieval routine.
             //
             String externalId = "";
             AccountDTO accountDTO = new AccountDTO();

--- a/src/main/java/org/openhmis/util/HibernateSessionFactory.java
+++ b/src/main/java/org/openhmis/util/HibernateSessionFactory.java
@@ -103,6 +103,7 @@ public class HibernateSessionFactory {
 	        configuration.addAnnotatedClass(org.openhmis.domain.TmpIncomeSource.class);
 	        configuration.addAnnotatedClass(org.openhmis.domain.PathClientRace.class);
 	        configuration.addAnnotatedClass(org.openhmis.domain.TmpDevelopmentalDisability.class);
+                configuration.addAnnotatedClass(org.openhmis.domain.TmpTokenCache.class);
 	        configuration.addAnnotatedClass(org.openhmis.domain.TmpUser.class);
 
 	        // Load the application properties based on the current context

--- a/src/main/java/org/openhmis/webservice/AuthenticationService.java
+++ b/src/main/java/org/openhmis/webservice/AuthenticationService.java
@@ -58,7 +58,7 @@ public class AuthenticationService {
 
 	@POST
 	@Path("/externalId")
-	public String getExternalId(@HeaderParam("Authorization") String authorization, String id_token) {
+	public Integer getExternalId(@HeaderParam("Authorization") String authorization, String id_token) {
                 /*
                  * We probably don't need to limit access to this
                  * endpoint to those with READ privileges on our server,
@@ -69,8 +69,10 @@ public class AuthenticationService {
 		if(!Authentication.googleAuthenticate(authorization, Authentication.READ))
                         throw new AccessDeniedException();
                 log.info("POST /externalId/ " + id_token);
-                String externalId = Authentication.resolveIdentity(id_token);
-                return externalId;
+                // Now sending the internal id, the user id, so that
+                // clients can exchange that for a full user object.
+                Integer userId = Authentication.resolveIdentity(id_token);
+                return userId;
 	}
 
         

--- a/src/main/java/org/openhmis/webservice/AuthenticationService.java
+++ b/src/main/java/org/openhmis/webservice/AuthenticationService.java
@@ -21,6 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
 
 import org.apache.log4j.Logger;
 import org.openhmis.code.ClientNameDataQuality;
+import org.openhmis.dto.AccountDTO;
 import org.openhmis.dto.ClientDTO;
 import org.openhmis.manager.ClientManager;
 
@@ -58,7 +59,7 @@ public class AuthenticationService {
 
 	@POST
 	@Path("/externalId")
-	public Integer getExternalId(@HeaderParam("Authorization") String authorization, String id_token) {
+	public AccountDTO getExternalId(@HeaderParam("Authorization") String authorization, String id_token) {
                 /*
                  * We probably don't need to limit access to this
                  * endpoint to those with READ privileges on our server,
@@ -71,8 +72,8 @@ public class AuthenticationService {
                 log.info("POST /externalId/ " + id_token);
                 // Now sending the internal id, the user id, so that
                 // clients can exchange that for a full user object.
-                Integer userId = Authentication.resolveIdentity(id_token);
-                return userId;
+                AccountDTO account = Authentication.resolveIdentity(id_token);
+                return account;
 	}
 
         

--- a/src/main/java/org/openhmis/webservice/AuthenticationService.java
+++ b/src/main/java/org/openhmis/webservice/AuthenticationService.java
@@ -70,8 +70,8 @@ public class AuthenticationService {
 		if(!Authentication.googleAuthenticate(authorization, Authentication.READ))
                         throw new AccessDeniedException();
                 log.info("POST /externalId/ " + id_token);
-                // Now sending the internal id, the user id, so that
-                // clients can exchange that for a full user object.
+                // Send an external ID and a user object, if the user
+                // exists in our database.
                 AccountDTO account = Authentication.resolveIdentity(id_token);
                 return account;
 	}

--- a/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
+++ b/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `TMP_TOKEN_CACHE` (
         tokenCacheId INT AUTO_INCREMENT PRIMARY KEY,
 	userId INT,
-	idToken VARCHAR(255) UNIQUE,
+	idToken TEXT,
 	dateCreated DATE,
 	dateUpdated DATE
 );

--- a/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
+++ b/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `TMP_TOKEN_CACHE` (
         tokenCacheId INT AUTO_INCREMENT PRIMARY KEY,
-	userId INT,
+	externalId VARCHAR(255),
 	idToken TEXT,
 	dateCreated DATE,
 	dateUpdated DATE

--- a/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
+++ b/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `TMP_TOKEN_CACHE` (
         tokenCacheId INT AUTO_INCREMENT PRIMARY KEY,
-	externalId VARCHAR(255),
+	externalId TEXT,
 	idToken TEXT,
 	dateCreated DATE,
 	dateUpdated DATE

--- a/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
+++ b/src/main/resources/db/migration/V030__CREATE_TMP_TOKEN_CACHE.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `TMP_TOKEN_CACHE` (
+        tokenCacheId INT AUTO_INCREMENT PRIMARY KEY,
+	userId INT,
+	idToken VARCHAR(255) UNIQUE,
+	dateCreated DATE,
+	dateUpdated DATE
+);


### PR DESCRIPTION
Add an endpoint for client apps that will return an external ID and a user object, if the external ID corresponds to a record in the `TMP_USER` table.  This PR includes a migration, so once it's merged run `mvn flyway:migrate` to apply it to the database.

Once this is merged, [the demo client's](https://github.com/hmis-tools/hmis-api-demo-client) master branch will work with the master branch of this repository again.

@kfogel and I talked briefly about the security implications for this new endpoint.  If a person has the `id_token` corresponding to a given Google address then they could log in to an HMIS server as that Google address anyway, so we don't think this opens up any additional risk.  Do let us know if we're overlooking something.
